### PR TITLE
Feature/post_index

### DIFF
--- a/src/app/Http/Controllers/Auth/LoginController.php
+++ b/src/app/Http/Controllers/Auth/LoginController.php
@@ -6,6 +6,9 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\LoginRequest;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
+use Illuminate\Http\Request;
+use Illuminate\Http\RedirectResponse;
+
 
 class LoginController extends Controller
 {
@@ -53,5 +56,22 @@ class LoginController extends Controller
         }
 
         return $this->sendFailedLoginResponse($request);
+    }
+
+    /**
+     * ログアウト
+     *
+     * @param Request $request
+     * @return RedirectResponse
+     */
+    public function logout(Request $request): RedirectResponse
+    {
+        $this->guard()->logout();
+
+        $request->session()->invalidate();
+
+        $request->session()->regenerateToken();
+
+        return redirect('/login');
     }
 }

--- a/src/app/Http/Controllers/Auth/LoginController.php
+++ b/src/app/Http/Controllers/Auth/LoginController.php
@@ -72,6 +72,6 @@ class LoginController extends Controller
 
         $request->session()->regenerateToken();
 
-        return redirect('/login');
+        return redirect(route('login'));
     }
 }

--- a/src/app/Http/Controllers/PostController.php
+++ b/src/app/Http/Controllers/PostController.php
@@ -53,7 +53,19 @@ class PostController extends Controller
         // タイトルと投稿の登録
         $this->postService->create($data);
 
-        // 後にポスト一覧に切り替える
-        return redirect(route('home'));
-    }   
+        return redirect(route('post.index'));
+    }
+
+    /**
+     * 投稿一覧の表示
+     *
+     * @return view
+     */
+    public function indexPost(): View
+    {
+        // 投稿一覧を取得して表示
+        $posts = $this->postService->index();
+
+        return view('post.index', compact('posts'));
+    }
 }

--- a/src/app/Http/Controllers/PostController.php
+++ b/src/app/Http/Controllers/PostController.php
@@ -64,7 +64,7 @@ class PostController extends Controller
     public function indexPost(): View
     {
         // 投稿一覧を取得して表示
-        $posts = $this->postService->index();
+        $posts = $this->postService->getAllPosts();
 
         return view('post.index', compact('posts'));
     }

--- a/src/app/Http/Controllers/UserController.php
+++ b/src/app/Http/Controllers/UserController.php
@@ -54,7 +54,6 @@ class UserController extends Controller
         event(new Registered($user));
         Auth::login($user);
 
-        // 後に投稿一覧ページにリダイレクトさせる
-        return redirect(route('home'));
+        return redirect(route('post.index'));
     }
 }

--- a/src/app/Models/Post.php
+++ b/src/app/Models/Post.php
@@ -3,7 +3,9 @@
 namespace App\Models;
 
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
@@ -34,5 +36,25 @@ class Post extends Model
             'title' => $data['title'],
             'post' => $data['post']
         ]);
+    }
+
+    /**
+     * 全投稿を取得
+     *
+     * @return LengthAwarePaginator
+     */
+    public function getAllPosts(): LengthAwarePaginator
+    {
+        return $this->orderBy("created_at", "desc")->paginate(config('const.ITEM_PER_PAGE'));
+    }
+
+    /**
+     * usersテーブルとtweetsテーブルのリレーションを貼る
+     *
+     * @return BelongsTo
+     */
+    public function user():BelongsTo
+    {
+        return $this->belongsTo(User::class);
     }
 }

--- a/src/app/Providers/RouteServiceProvider.php
+++ b/src/app/Providers/RouteServiceProvider.php
@@ -17,7 +17,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    public const HOME = '/home';
+    public const HOME = '/post/index';
 
     /**
      * Define your route model bindings, pattern filters, and other route configuration.

--- a/src/app/Services/PostService.php
+++ b/src/app/Services/PostService.php
@@ -40,7 +40,7 @@ class PostService
      *
      * @return LengthAwarePaginator
      */
-    public function index(): LengthAwarePaginator
+    public function getAllPosts(): LengthAwarePaginator
     {
         return $this->post->getAllPosts();
     }

--- a/src/app/Services/PostService.php
+++ b/src/app/Services/PostService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Models\Post;
+use Illuminate\Pagination\LengthAwarePaginator;
 
 class PostService
 {
@@ -29,8 +30,18 @@ class PostService
      * @param array $data
      * @return void
      */
-    public function create(array $data)
+    public function create(array $data): void
     {
         $this->post->store($data);
+    }
+
+    /**
+     * モデルの全データを取得するメソッドの呼び出し
+     *
+     * @return LengthAwarePaginator
+     */
+    public function index(): LengthAwarePaginator
+    {
+        return $this->post->getAllPosts();
     }
 }

--- a/src/config/const.php
+++ b/src/config/const.php
@@ -2,7 +2,9 @@
 
 return [
     // アイコンが選択されなかった時
-    'NOICON_PATH' => 'storage/noicon/noicon.png',
+    'NOICON_PATH' => 'storage/profileIcons/noicon.png',
     // アイコンが選択された時
     'ICON_PATH' => 'public/profileIcons',
+    // ページネーションの時
+    'ITEM_PER_PAGE' => 7,
 ];

--- a/src/public/css/index.css
+++ b/src/public/css/index.css
@@ -1,0 +1,20 @@
+#icon-image {
+    width: 50px;
+    height: 50px;
+    border-radius: 50%; /* アイコンを丸くする */
+    object-fit: cover; 
+    margin-right: 10px; /* 画像と名前の間に少し間隔を入れる */
+}
+
+.title-container {
+    width: 1200px; /* タイトルの枠の長さ */
+    white-space: nowrap; /* 折り返しを防ぐ */
+    overflow: hidden; /* 内容が枠を超えた場合に非表示にする */
+    text-overflow: ellipsis; /* 内容が枠を超えた場合に...と表示する */
+}
+
+.center {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}

--- a/src/resources/views/auth/register.blade.php
+++ b/src/resources/views/auth/register.blade.php
@@ -26,7 +26,7 @@
                                         </div>
                                     </div>
                                     <div class="icon-preview-wrapper">
-                                        <img id="icon-preview" src="{{ asset('storage/noicon/noicon.png') }}">
+                                        <img id="icon-preview" src="{{ asset('storage/profileIcons/noicon.png') }}">
                                     </div>
                                 </div>
 

--- a/src/resources/views/components/header.blade.php
+++ b/src/resources/views/components/header.blade.php
@@ -42,6 +42,10 @@
                         <a class="nav-link" href="{{ route('post.show') }}">{{ __('投稿') }}</a>
                     </li>
 
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ route('post.index') }}">{{ __('投稿一覧') }}</a>
+                    </li>
+
                     <li class="nav-item dropdown">
                         <a id="navbarDropdown" class="nav-link dropdown-toggle" href="#" role="button"
                             data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" v-pre>

--- a/src/resources/views/post/index.blade.php
+++ b/src/resources/views/post/index.blade.php
@@ -1,0 +1,33 @@
+@extends('layouts.app')
+
+@push('style')
+    <link rel="stylesheet" href="{{ asset('/css/index.css') }}">
+@endpush
+
+@section('content')
+    <div class="container ">        
+        <ul class="list-group">
+            @forelse($posts as $post)
+                {{-- <a class="text-decoration-none tweet-card-link" href="{{ route('tweet.show', ['id' => $tweet->id]) }}"> --}}
+                    <div class="d-flex align-items-center mb-2">
+                        <img id="icon-image" src="{{ asset('storage/profileIcons/' . basename($post->user->icon)) }}">
+                        <div>
+                                <strong>{{ $post->user->name }}</strong>
+                            <li class="list-group-item mb-4 rounded title-container">
+                                    {{ $post->title }}
+                            </li>
+                        </div>
+                    </div>
+                {{-- </a> --}}
+
+            @empty
+                <div class="mb-4 text-center">
+                    <li class="list-group-item rounded">投稿は存在しません</li>
+                </div>
+            @endforelse
+        </ul>
+        <div class="d-flex justify-content-center">
+        {{ $posts->links('pagination::bootstrap-4') }}
+        </div>
+    </div>
+@endsection

--- a/src/resources/views/post/index.blade.php
+++ b/src/resources/views/post/index.blade.php
@@ -8,17 +8,15 @@
     <div class="container ">        
         <ul class="list-group">
             @forelse($posts as $post)
-                {{-- <a class="text-decoration-none tweet-card-link" href="{{ route('tweet.show', ['id' => $tweet->id]) }}"> --}}
                     <div class="d-flex align-items-center mb-2">
                         <img id="icon-image" src="{{ asset('storage/profileIcons/' . basename($post->user->icon)) }}">
                         <div>
-                                <strong>{{ $post->user->name }}</strong>
+                            <strong>{{ $post->user->name }}</strong>
                             <li class="list-group-item mb-4 rounded title-container">
-                                    {{ $post->title }}
+                                {{ $post->title }}
                             </li>
                         </div>
                     </div>
-                {{-- </a> --}}
 
             @empty
                 <div class="mb-4 text-center">

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -34,9 +34,11 @@ Route::post('/user/create', [UserController::class, 'create'])->name('userStore'
 Route::group(['middleware' => 'auth'], function() {
     // postグループ
     Route::group(['prefix' => 'post', 'as' => 'post'], function() {
-        // post作成画面を表示
+        // 投稿作成画面を表示
         Route::get('/create', [PostController::class, 'showPost'])->name('.show');
-        // postを作成
+        // 投稿を作成
         Route::post('/create', [PostController::class, 'createPost'])->name('.create');
+        // 投稿一覧画面を表示
+        Route::get('/index', [PostController::class, 'indexPost'])->name('.index');
     });
 });


### PR DESCRIPTION
# 課題のリンク
- 投稿一覧を見ることができる機能

# 改修内容
- ログインした時に遷移するページをhome画面から投稿一覧画面に変更
-  投稿が完了した時に遷移するページをhome画面から投稿一覧画面に変更
- ログアウトした時に遷移するページをwelcome画面からログイン画面に変更
- 投稿一覧画面に遷移できるボタンをヘッダーに追加
- 投稿一覧画面で投稿した人の名前・アイコン、投稿のタイトル、日付を見ることができる
- 投稿一覧画面に１度に表示できる量（投稿7個）を超えると次のページに表示される
- 投稿がひとつもない場合は「投稿が存在しません」と表示される

# キャプチャ
https://github.com/suqqupanda/knowledge/assets/111690436/053a3819-89c0-4811-97bc-a0e446a2a665

# 検証内容
- 画面が正しく遷移するか目視で確認
- 投稿がない時に「投稿が存在しません」と表示されるか目視で確認
- 投稿したものが一覧に反映されるか目視で確認

# 相談事項
- ログインできないバグをfeature/post_index で直してしまったが、feature/registerなどで直すべきだったか聞きたいです！
- Serviceに処理を書いてみたが、間違った使い方をしている気がします。。。

# 注意事項
- なし