### PR TITLE
fearure/post_detail

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,4 @@
+{
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+}  

--- a/src/app/Http/Controllers/PostController.php
+++ b/src/app/Http/Controllers/PostController.php
@@ -68,4 +68,23 @@ class PostController extends Controller
 
         return view('post.index', compact('posts'));
     }
+
+    /**
+     * 投稿の詳細を表示
+     *
+     * @param integer $postId
+     * @return View
+     */
+    public function detailPost(int $postId): View
+    {
+        $post = $this->postService->getPostById($postId);
+
+        // 投稿が存在しない場合
+        if (is_null($post))
+        {
+            return redirect(route('post.index'))->with('error', 'Post not found');
+        }
+
+        return view('post.detail', compact('post'));
+    }
 }

--- a/src/app/Http/Controllers/PostController.php
+++ b/src/app/Http/Controllers/PostController.php
@@ -73,9 +73,9 @@ class PostController extends Controller
      * 投稿の詳細を表示
      *
      * @param integer $postId
-     * @return View
+     * @return View|Redirectresponse
      */
-    public function detailPost(int $postId): View
+    public function detailPost(int $postId): View|Redirectresponse
     {
         $post = $this->postService->getPostById($postId);
 

--- a/src/app/Models/Post.php
+++ b/src/app/Models/Post.php
@@ -24,6 +24,16 @@ class Post extends Model
     ];
 
     /**
+     * usersテーブルとtweetsテーブルのリレーションを貼る
+     *
+     * @return BelongsTo
+     */
+    public function user():BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
      * 投稿を登録
      *
      * @param array $data
@@ -49,12 +59,13 @@ class Post extends Model
     }
 
     /**
-     * usersテーブルとtweetsテーブルのリレーションを貼る
+     * 特定の投稿の情報を取得
      *
-     * @return BelongsTo
+     * @param integer $postId
+     * @return Post|null
      */
-    public function user():BelongsTo
+    public function getPostById(int $postId): Post|null
     {
-        return $this->belongsTo(User::class);
+        return Post::find($postId);
     }
 }

--- a/src/app/Services/PostService.php
+++ b/src/app/Services/PostService.php
@@ -36,12 +36,23 @@ class PostService
     }
 
     /**
-     * モデルの全データを取得するメソッドの呼び出し
+     * モデルの全投稿を取得するメソッドの呼び出し
      *
      * @return LengthAwarePaginator
      */
     public function getAllPosts(): LengthAwarePaginator
     {
         return $this->post->getAllPosts();
+    }
+
+    /**
+     * モデルの特定の投稿を取得するメソッドの呼び出し
+     *
+     * @param integer $postId
+     * @return Post|null
+     */
+    public function getPostById(int $postId): Post|null
+    {
+        return $this->post->getPostById($postId);
     }
 }

--- a/src/public/css/detail.css
+++ b/src/public/css/detail.css
@@ -1,0 +1,8 @@
+#icon-image {
+    width: 75px;
+    height: 75px;
+    border-radius: 50%; /* アイコンを丸くする */
+    object-fit: cover; 
+    margin-right: 10px; /* 画像と名前の間に少し間隔を入れる */
+    transform: translate(45px,75px);
+}

--- a/src/public/css/detail.css
+++ b/src/public/css/detail.css
@@ -6,3 +6,8 @@
     margin-right: 10px; /* 画像と名前の間に少し間隔を入れる */
     transform: translate(45px,75px);
 }
+
+.date-container {
+    text-align: right;
+    margin-right: 12%;  /* またはお好みの値に変更 */
+    }

--- a/src/resources/views/post/detail.blade.php
+++ b/src/resources/views/post/detail.blade.php
@@ -43,4 +43,7 @@
             </div>
         </div>
     </div>
+    <div class="date-container">
+        {{ $post->created_at->format('Y年m月d日') }}
+    </div>
 @endsection

--- a/src/resources/views/post/detail.blade.php
+++ b/src/resources/views/post/detail.blade.php
@@ -1,0 +1,46 @@
+@extends('layouts.app')
+
+@push('style')
+    <link rel="stylesheet" href="{{ asset('/css/detail.css') }}">
+@endpush
+
+@section('content')
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-8">
+                <div class="card">
+                    <div class="card-header">{{ __('Post Details') }}</div>
+
+                    <div class="card-body">
+                        <img id="icon-image" src="{{ asset('storage/profileIcons/' . basename($post->user->icon)) }}">
+                        <div class="post-group">
+                            <div class="row mb-3">
+                                <div class="col-md-8 offset-md-2">
+                                    <label for="title">{{ __('タイトル') }}</label>
+                                    <textarea id="title" class="form-control" name="title" rows="1" readonly>{{ $post->title }}</textarea>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="post-group">
+                            <div class="row mb-4">
+                                <div class="col-md-8 offset-md-2">
+                                    <label for="post">{{ __('投稿内容') }}</label>
+                                    <textarea id="post" class="form-control" name="post" rows="10" readonly>{{ $post->post }}</textarea>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="row mb-4 justify-content-center">
+                            <div class="col-md-4 d-flex justify-content-center">
+                                <a href="{{ route('post.index') }}" class="btn btn-light btn-outline-dark rounded-pill">
+                                    {{ __('戻る') }}
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/src/resources/views/post/index.blade.php
+++ b/src/resources/views/post/index.blade.php
@@ -5,18 +5,21 @@
 @endpush
 
 @section('content')
-    <div class="container ">        
+    <div class="container ">
         <ul class="list-group">
             @forelse($posts as $post)
-                    <div class="d-flex align-items-center mb-2">
-                        <img id="icon-image" src="{{ asset('storage/profileIcons/' . basename($post->user->icon)) }}">
-                        <div>
-                            <strong>{{ $post->user->name }}</strong>
+                <div class="d-flex align-items-center mb-2">
+                    <img id="icon-image" src="{{ asset('storage/profileIcons/' . basename($post->user->icon)) }}">
+                    <div>
+                        <strong>{{ $post->user->name }}</strong>
+                        <a class="text-decoration-none post-card-link" href="{{ route('post.detail', ['id' => $post->id]) }}">
                             <li class="list-group-item mb-4 rounded title-container">
                                 {{ $post->title }}
                             </li>
-                        </div>
+                        </a>
                     </div>
+                </div>
+
 
             @empty
                 <div class="mb-4 text-center">
@@ -25,7 +28,7 @@
             @endforelse
         </ul>
         <div class="d-flex justify-content-center">
-        {{ $posts->links('pagination::bootstrap-4') }}
+            {{ $posts->links('pagination::bootstrap-4') }}
         </div>
     </div>
 @endsection

--- a/src/resources/views/post/post.blade.php
+++ b/src/resources/views/post/post.blade.php
@@ -45,7 +45,7 @@
 
                         <div class="row mb-0 justify-content-center">
                             <div class="col-md-2">
-                            <a href="{{ route('home') }}" class="btn btn-light btn-outline-dark rounded-pill">
+                            <a href="{{ route('post.index') }}" class="btn btn-light btn-outline-dark rounded-pill">
                                 {{ __('キャンセル') }}
                             </a>
                             </div>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -40,5 +40,7 @@ Route::group(['middleware' => 'auth'], function() {
         Route::post('/create', [PostController::class, 'createPost'])->name('.create');
         // 投稿一覧画面を表示
         Route::get('/index', [PostController::class, 'indexPost'])->name('.index');
+        // 投稿詳細画面を表示
+        Route::get('/detail/{id}', [PostController::class, 'detailPost'])->name('.detail');
     });
 });


### PR DESCRIPTION
# 課題のリンク
- 投稿詳細を見ることができる機能

# 改修内容
- 投稿一覧画面で表示されている投稿のタイトルをクリックするとその投稿の詳細画面に遷移する
- 投稿詳細画面ではアイコン画像・タイトル・投稿内容・戻るボタン・日付が表示される
- 戻るボタンを押すと投稿一覧画面に遷移する

# キャプチャ
https://github.com/suqqupanda/knowledge/assets/111690436/27ed8fc7-19b0-410a-b881-b243acad4ab2

# 検証内容
- タイトルを押して正しい投稿の詳細が表示されるかを目視で確認
- 戻るボタンを押すと投稿一覧画面に遷移することを目視で確認
- 存在しないpostIdを渡した時に投稿一覧画面に戻ることを目視で確認

# 相談事項

# 注意事項
- commitがわかりにくくなってしまったので次回からもっと細かく分けてわかりやすくします。